### PR TITLE
allow ClusterForm to accept the 'formsets' parameter as a dict

### DIFF
--- a/modelcluster/forms.py
+++ b/modelcluster/forms.py
@@ -206,10 +206,21 @@ class ClusterFormMetaclass(ModelFormMetaclass):
                 except AttributeError:  # thrown if opts.widgets is None
                     widgets = None
 
-                formset = childformset_factory(opts.model, rel.model,
-                    extra=cls.extra_form_count,
-                    formfield_callback=formfield_callback, fk_name=rel.field.name,
-                    widgets=widgets)
+                kwargs = {
+                    'extra': cls.extra_form_count,
+                    'formfield_callback': formfield_callback,
+                    'fk_name': rel.field.name,
+                    'widgets': widgets
+                }
+
+                # see if opts.formsets looks like a dict; if so, allow the value
+                # to override kwargs
+                try:
+                    kwargs.update(opts.formsets.get(rel_name))
+                except AttributeError:
+                    pass
+
+                formset = childformset_factory(opts.model, rel.model, **kwargs)
                 formsets[rel_name] = formset
 
             new_class.formsets = formsets

--- a/tests/tests/test_cluster_form.py
+++ b/tests/tests/test_cluster_form.py
@@ -132,6 +132,26 @@ class ClusterFormTest(TestCase):
         self.assertEqual(Textarea, type(form['name'].field.widget))
         self.assertEqual(Textarea, type(form.formsets['members'].forms[0]['name'].field.widget))
 
+    def test_explicit_formset_dict(self):
+        class BandForm(ClusterForm):
+            class Meta:
+                model = Band
+                formsets = {
+                    'albums': {'fields': ['name'], 'widgets': {'name': Textarea()}}
+                }
+                fields = ['name']
+
+        form = BandForm()
+        self.assertTrue(form.formsets.get('albums'))
+        self.assertFalse(form.formsets.get('members'))
+
+        self.assertTrue('albums' in form.as_p())
+        self.assertFalse('members' in form.as_p())
+
+        self.assertIn('name', form.formsets['albums'].forms[0].fields)
+        self.assertNotIn('release_date', form.formsets['albums'].forms[0].fields)
+        self.assertEqual(Textarea, type(form.formsets['albums'].forms[0]['name'].field.widget))
+
     def test_formfield_callback(self):
 
         def formfield_for_dbfield(db_field, **kwargs):


### PR DESCRIPTION
Currently, the 'formsets' property on a `ClusterForm` is just a list of relation names:

        class BandForm(ClusterForm):
            class Meta:
                model = Band
                formsets = ['members', 'albums']
                fields = ['name']

Turning these relations into formsets is mostly left up to Django's `modelformset_factory` function, at its default settings. A handful of properties ('extra', 'widgets', 'formfield_callback') are picked up from the outer form, but there's no way to customise each formset's properties individually.

In particular, there's no way to specify a 'fields' (or 'exclude') property, which is compulsory as of Django 1.8, and is also necessary to fix https://github.com/torchbox/wagtail/issues/922 (which arises because there's no way to cut the field list down to just the ones declared in panel definitions). This PR addresses that by allowing 'formsets' to be specified as a dict instead of a list, where each value is a dict of overridden settings for that formset:

        class BandForm(ClusterForm):
            class Meta:
                model = Band
                formsets = {
                    'members': {'fields': ['name']},
                    'albums': {'exclude': ['release_date'], 'widgets': {'name': Textarea()}},
                }
                fields = ['name']
