### PR TITLE
ChildFormSet.save should apply child ordering without needing to save to DB - fixes #13

### DIFF
--- a/modelcluster/fields.py
+++ b/modelcluster/fields.py
@@ -4,6 +4,8 @@ from django.db import models, IntegrityError, router
 from django.db.models.fields.related import ForeignKey, ForeignRelatedObjectsDescriptor
 from django.utils.functional import cached_property
 
+from modelcluster.utils import sort_by_fields
+
 try:
     from south.modelsinspector import add_introspection_rules
 except ImportError:
@@ -131,19 +133,7 @@ def create_deferring_foreign_related_manager(related, original_manager_cls):
 
             # Sort list
             if rel_model._meta.ordering and len(items) > 1:
-                # To get the desired behaviour, we need to order by keys in reverse order
-                # See: https://docs.python.org/2/howto/sorting.html#sort-stability-and-complex-sorts
-                for key in reversed(rel_model._meta.ordering):
-                    # Check if this key has been reversed
-                    reverse = False
-                    if key[0] == '-':
-                        reverse = True
-                        key = key[1:]
-
-                    # Sort
-                    # Use a tuple of (v is not None, v) as the key, to ensure that None sorts before other values,
-                    # as comparing directly with None breaks on python3
-                    items[:] = sorted(items, key=lambda x: (getattr(x, key) is not None, getattr(x, key)), reverse=reverse)
+                sort_by_fields(items, rel_model._meta.ordering)
 
         def remove(self, *items_to_remove):
             """

--- a/modelcluster/forms.py
+++ b/modelcluster/forms.py
@@ -60,6 +60,13 @@ class BaseChildFormSet(BaseTransientModelFormSet):
 
         manager = getattr(self.instance, self.rel_name)
 
+        # if model has a sort_order_field defined, assign order indexes to the attribute
+        # named in it
+        if self.can_order and hasattr(self.model, 'sort_order_field'):
+            sort_order_field = getattr(self.model, 'sort_order_field')
+            for i, form in enumerate(self.ordered_forms):
+                setattr(form.instance, sort_order_field, i)
+
         # If the manager has existing instances with a blank ID, we have no way of knowing
         # whether these correspond to items in the submitted data. We'll assume that they do,
         # as that's the most common case (i.e. the formset contains the full set of child objects,
@@ -71,13 +78,6 @@ class BaseChildFormSet(BaseTransientModelFormSet):
 
         manager.add(*saved_instances)
         manager.remove(*self.deleted_objects)
-
-        # if model has a sort_order_field defined, assign order indexes to the attribute
-        # named in it
-        if self.can_order and hasattr(self.model, 'sort_order_field'):
-            sort_order_field = getattr(self.model, 'sort_order_field')
-            for i, form in enumerate(self.ordered_forms):
-                setattr(form.instance, sort_order_field, i)
 
         if commit:
             manager.commit()

--- a/modelcluster/queryset.py
+++ b/modelcluster/queryset.py
@@ -2,6 +2,8 @@ from __future__ import unicode_literals
 
 from django.db.models import Model
 
+from modelcluster.utils import sort_by_fields
+
 # Constructor for test functions that determine whether an object passes some boolean condition
 def test_exact(model, attribute_name, value):
     field = model._meta.get_field(attribute_name)
@@ -105,6 +107,11 @@ class FakeQuerySet(object):
                 tuple([getattr(obj, field_name) for field_name in fields])
                 for obj in self.results
             ]
+
+    def order_by(self, *fields):
+        results = self.results[:]  # make a copy of results
+        sort_by_fields(results, fields)
+        return FakeQuerySet(self.model, results)
 
     def __getitem__(self, k):
         return self.results[k]

--- a/modelcluster/utils.py
+++ b/modelcluster/utils.py
@@ -1,0 +1,19 @@
+def sort_by_fields(items, fields):
+    """
+    Sort a list of objects on the given fields. The field list works analogously to
+    queryset.order_by(*fields): each field is either a property of the object,
+    or is prefixed by '-' (e.g. '-name') to indicate reverse ordering.
+    """
+    # To get the desired behaviour, we need to order by keys in reverse order
+    # See: https://docs.python.org/2/howto/sorting.html#sort-stability-and-complex-sorts
+    for key in reversed(fields):
+        # Check if this key has been reversed
+        reverse = False
+        if key[0] == '-':
+            reverse = True
+            key = key[1:]
+
+        # Sort
+        # Use a tuple of (v is not None, v) as the key, to ensure that None sorts before other values,
+        # as comparing directly with None breaks on python3
+        items.sort(key=lambda x: (getattr(x, key) is not None, getattr(x, key)), reverse=reverse)


### PR DESCRIPTION
This PR fixes #13 aka https://github.com/torchbox/wagtail/issues/867, where saving a set of child objects via an ordered ChildFormSet and then accessing the relation (without writing back to the DB in between) causes the children to be returned in the original form order, rather than the order indicated by the 'myformset-n-ORDER' fields.

This was caused by an oversight in the ChildFormSet.save logic: DeferringRelatedManager.add takes care of reordering the children on insertion according to Meta.ordering, but our call to 'add' happened before we'd updated the all-important sort_order field.

As a bonus, this PR also implements FakeQuerySet.order_by. I didn't see that DeferringRelatedManager.add implemented the sorting logic until I'd already implemented it myself within FakeQuerySet, so I took the opportunity to move the existing (better-tested) implementation into a utils module where it could be used in both places.