### PR TITLE
Remove South

### DIFF
--- a/modelcluster/contrib/taggit.py
+++ b/modelcluster/contrib/taggit.py
@@ -16,13 +16,6 @@ def get_field_rel(field):
         return field.related
 
 
-try:
-    from south.modelsinspector import add_ignored_fields
-except ImportError:
-    # south is not in use, so make add_ignored_fields a no-op
-    def add_ignored_fields(*args):
-        pass
-
 class _ClusterTaggableManager(_TaggableManager):
     @require_instance_manager
     def get_tagged_item_manager(self):
@@ -109,7 +102,3 @@ class ClusterTaggableManager(TaggableManager):
         # the live database
         rel_name = get_field_rel(self.through._meta.get_field('content_object')).get_accessor_name()
         return getattr(instance, rel_name).all()
-
-
-# tell south to ignore ClusterTaggableManager, like it ignores taggit.TaggableManager
-add_ignored_fields(["^modelcluster\.contrib\.taggit\.ClusterTaggableManager"])

--- a/modelcluster/fields.py
+++ b/modelcluster/fields.py
@@ -6,13 +6,6 @@ from django.utils.functional import cached_property
 
 from modelcluster.utils import sort_by_fields
 
-try:
-    from south.modelsinspector import add_introspection_rules
-except ImportError:
-    # south is not in use, so make add_introspection_rules a no-op
-    def add_introspection_rules(*args):
-        pass
-
 from modelcluster.queryset import FakeQuerySet
 from modelcluster.models import get_related_model
 
@@ -250,5 +243,3 @@ class ParentalKey(ForeignKey):
             cls._meta.child_relations.append(related)
         except AttributeError:
             cls._meta.child_relations = [related]
-
-add_introspection_rules([], ["^modelcluster\.fields\.ParentalKey"])


### PR DESCRIPTION
Now that Django 1.6 support is gone, there's no need for South anymore.