### PR TITLE
Add imports to README example

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -29,7 +29,11 @@ Unfortunately, you can't. Objects need to exist in the database for foreign key 
 But what if you could? There are all sorts of scenarios where you might want to work with a 'cluster' of related objects, without necessarily holding them in the database: maybe you want to render a preview of the data the user has just submitted, prior to saving. Maybe you need to construct a tree of things, serialize them and hand them off to some external system. Maybe you have a workflow where your models exist in an incomplete 'draft' state for an extended time, or you need to handle multiple revisions, and you don't want to redesign your database around that requirement.
 
 **django-modelcluster** extends Django's foreign key relations to make this possible. It introduces a new type of relation, *ParentalKey*, where the related models are stored locally to the 'parent' model until the parent is explicitly saved. Up to that point, the related models can still be accessed through a subset of the QuerySet API::
-
+ 
+ from modelcluster.models import ClusterableModel
+ from modelcluster.fields import ParentalKey
+ 
+ 
  class Band(ClusterableModel):
      name = models.CharField(max_length=255)
 


### PR DESCRIPTION
Added proper import strings for `ParentalKey` and `ClusterableModel` for easier installation/configuration.