### PR TITLE
Remove monkeypatching of ParentalKey.contribute_to_related_class to set related_accessor_class

### DIFF
--- a/modelcluster/fields.py
+++ b/modelcluster/fields.py
@@ -224,19 +224,8 @@ class ParentalKey(ForeignKey):
     # ForeignKeys. Disable it
     allow_unsaved_instance_assignment = True
 
-    # prior to https://github.com/django/django/commit/fa2e1371cda1e72d82b4133ad0b49a18e43ba411
-    # ForeignRelatedObjectsDescriptor is hard-coded in contribute_to_related_class -
-    # so we need to patch in that change to look up related_accessor_class instead
     def contribute_to_related_class(self, cls, related):
-        # Internal FK's - i.e., those with a related name ending with '+' -
-        # and swapped models don't get a related descriptor.
-        related_model = get_related_model(related)
-        if not self.rel.is_hidden() and not related_model._meta.swapped:
-            setattr(cls, related.get_accessor_name(), self.related_accessor_class(related))
-            if self.rel.limit_choices_to:
-                cls._meta.related_fkey_lookups.append(self.rel.limit_choices_to)
-        if self.rel.field_name is None:
-            self.rel.field_name = cls._meta.pk.name
+        super(ParentalKey, self).contribute_to_related_class(cls, related)
 
         # store this as a child field in meta. NB child_relations only contains relations
         # defined to this specific model, not its superclasses


### PR DESCRIPTION
Django 1.7 introduced the ability to pass in a custom related_accessor_class to use as the accessor on the related model, instead of hardcoding ForeignRelatedObjectsDescriptor: https://github.com/django/django/commit/fa2e1371cda1e72d82b4133ad0b49a18e43ba411

To provide this facility on Django 1.6, we had to duplicate the Django 1.7 code as a monkeypatch. Now that we've dropped 1.6 support, this monkeypatch can be removed.