### PR TITLE
Verify is is self.rel.to is a class

### DIFF
--- a/modelcluster/fields.py
+++ b/modelcluster/fields.py
@@ -257,7 +257,8 @@ class ParentalKey(ForeignKey):
         errors = super(ParentalKey, self).check(**kwargs)
 
         # Check that the desination model is a subclass of ClusterableModel
-        if not issubclass(self.rel.to, ClusterableModel):
+        import inspect
+        if inspect.isclass(self.rel.to) and not issubclass(self.rel.to, ClusterableModel):
             errors.append(
                 checks.Error(
                     'ParentalKey must point to a subclass of ClusterableModel.',


### PR DESCRIPTION
if self.rel.to is not a class (ejm. String instance ), issubclass throw a unexpected exception "issubclass() arg 1 must be a class", and the others errors(the important errors), are encapsulated.