### PR TITLE
Fix case sensitive query on tag save that caused Integrity error

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -1,6 +1,10 @@
 Changelog
 =========
 
+1.1.1 (04.02.2016)
+~~~~~~~~~~~~~~~~
+* Fix: Made adding tags case insensitive if TAGGIT_CASE_INSENSITIVE setting is True for contrib app. Without it, attempted saves not careful of case sensitivity would cause Integrity error
+
 1.1 (17.12.2015)
 ~~~~~~~~~~~~~~~~
 * Django 1.9 compatibility


### PR DESCRIPTION
This fixes an Integrity Error that is received when a user inputs the same word(s) as an existing tag but in a different case. Now, if the `TAGGIT_CASE_INSENSITIVE` setting is True then the tag lookup for existing tags will be case insensitive.