### PR TITLE
Call pre_save to get field value

### DIFF
--- a/modelcluster/models.py
+++ b/modelcluster/models.py
@@ -25,7 +25,7 @@ def get_related_model(rel):
 
 def get_field_value(field, model):
     if field.rel is None:
-        value = field._get_val_from_obj(model)
+        value = field.pre_save(model, add=model.pk is None)
 
         # Make datetimes timezone aware
         # https://github.com/django/django/blob/master/django/db/models/fields/__init__.py#L1394-L1403


### PR DESCRIPTION
pre_save calls the same method as called previously, but also allows FileFields and others to save their contents as part of the save action.

This fixes torchbox/wagtail#2181