### PR TITLE
Make prefetch_related not fail on ClusterTaggableManager - fixes #54

### DIFF
--- a/modelcluster/contrib/taggit.py
+++ b/modelcluster/contrib/taggit.py
@@ -27,17 +27,21 @@ class _ClusterTaggableManager(_TaggableManager):
         rel_name = get_field_rel(self.through._meta.get_field('content_object')).get_accessor_name()
         return getattr(self.instance, rel_name)
 
-    def get_query_set(self):
-        # FIXME: we ought to have some way of querying the tagged item manager about whether
-        # it has uncommitted changes, and return a real queryset (using the original taggit logic)
-        # if not
-        return FakeQuerySet(
-            self.through.tag_model(),
-            [tagged_item.tag for tagged_item in self.get_tagged_item_manager().all()]
-        )
-
-    # Django 1.6 renamed this
-    get_queryset = get_query_set
+    def get_queryset(self, extra_filters=None):
+        if self.instance is None:
+            # this manager is not associated with a specific model instance
+            # (which probably means it's being invoked within a prefetch_related operation);
+            # this means that we don't have to deal with uncommitted models/tags, and can just
+            # use the standard taggit handler
+            return super(_ClusterTaggableManager, self).get_queryset(extra_filters)
+        else:
+            # FIXME: we ought to have some way of querying the tagged item manager about whether
+            # it has uncommitted changes, and return a real queryset (using the original taggit logic)
+            # if not
+            return FakeQuerySet(
+                self.through.tag_model(),
+                [tagged_item.tag for tagged_item in self.get_tagged_item_manager().all()]
+            )
 
     @require_instance_manager
     def add(self, *tags):


### PR DESCRIPTION
It doesn't actually do the prefetching yet, but at least it doesn't break completely...