### PR TITLE
Bring _ClusterTaggableManager.add back in sync with django-taggit

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -5,8 +5,10 @@ Changelog
 ~~~~~~~~~~~~~~~~
 * Removed Django 1.7 and Python 3.2 support
 * Added system check to disallow related_name='+' on ParentalKey
+* Added support for TAGGIT_CASE_INSENSITIVE on ClusterTaggableManager
 * Fix: System checks now correctly report a model name that cannot be resolved to a model
 * Fix: prefetch_related on a ClusterTaggableManager no longer fails (but doesn't prefetch either)
+* Fix: Adding invalid types as tags now correctly reports a ValueError
 
 1.1 (17.12.2015)
 ~~~~~~~~~~~~~~~~

--- a/modelcluster/contrib/taggit.py
+++ b/modelcluster/contrib/taggit.py
@@ -1,6 +1,8 @@
 from __future__ import unicode_literals
 from __future__ import absolute_import
 
+from django.conf import settings
+from django.utils import six
 from taggit.managers import TaggableManager, _TaggableManager
 from taggit.utils import require_instance_manager
 
@@ -39,20 +41,41 @@ class _ClusterTaggableManager(_TaggableManager):
         # First turn the 'tags' list (which may be a mixture of tag objects and
         # strings which may or may not correspond to existing tag objects)
         # into 'tag_objs', a set of tag objects
-        str_tags = set([
-            t
-            for t in tags
-            if not isinstance(t, self.through.tag_model())
-        ])
-        tag_objs = set(tags) - str_tags
-        # If str_tags has 0 elements Django actually optimizes that to not do a
-        # query.  Malcolm is very smart.
-        existing = self.through.tag_model().objects.filter(
-            name__in=str_tags
-        )
+        str_tags = set()
+        tag_objs = set()
+        for t in tags:
+            if isinstance(t, self.through.tag_model()):
+                tag_objs.add(t)
+            elif isinstance(t, six.string_types):
+                str_tags.add(t)
+            else:
+                raise ValueError("Cannot add {0} ({1}). Expected {2} or str.".format(
+                    t, type(t), type(self.through.tag_model())))
+
+        if getattr(settings, 'TAGGIT_CASE_INSENSITIVE', False):
+            # Some databases can do case-insensitive comparison with IN, which
+            # would be faster, but we can't rely on it or easily detect it.
+            existing = []
+            tags_to_create = []
+
+            for name in str_tags:
+                try:
+                    tag = self.through.tag_model().objects.get(name__iexact=name)
+                    existing.append(tag)
+                except self.through.tag_model().DoesNotExist:
+                    tags_to_create.append(name)
+        else:
+            # If str_tags has 0 elements Django actually optimizes that to not do a
+            # query.  Malcolm is very smart.
+            existing = self.through.tag_model().objects.filter(
+                name__in=str_tags
+            )
+
+            tags_to_create = str_tags - set(t.name for t in existing)
+
         tag_objs.update(existing)
 
-        for new_tag in str_tags - set(t.name for t in existing):
+        for new_tag in tags_to_create:
             tag_objs.add(self.through.tag_model().objects.create(name=new_tag))
 
         # Now write these to the relation

--- a/tests/tests/test_tag.py
+++ b/tests/tests/test_tag.py
@@ -2,7 +2,7 @@ from __future__ import unicode_literals
 
 import unittest
 
-from django.test import TestCase
+from django.test import TestCase, override_settings
 from taggit.models import Tag
 from modelcluster.forms import ClusterForm
 
@@ -93,3 +93,19 @@ class TagTest(TestCase):
         self.assertTrue(Tag.objects.get(name='burrito') in mission_burrito.tags.all())
         self.assertTrue(Tag.objects.get(name='fajita') in mission_burrito.tags.all())
         self.assertFalse(Tag.objects.get(name='mexican') in mission_burrito.tags.all())
+
+    @override_settings(TAGGIT_CASE_INSENSITIVE=True)
+    def test_case_insensitive_tags(self):
+        mission_burrito = Place(name='Mission Burrito')
+        mission_burrito.tags.add('burrito')
+        mission_burrito.tags.add('Burrito')
+
+        self.assertEqual(1, mission_burrito.tags.count())
+
+    def test_integers(self):
+        """Adding an integer as a tag should raise a ValueError"""
+        mission_burrito = Place(name='Mission Burrito')
+        with self.assertRaisesRegexp(ValueError, (
+                r"Cannot add 1 \(<(type|class) 'int'>\). "
+                r"Expected <class 'django.db.models.base.ModelBase'> or str.")):
+            mission_burrito.tags.add(1)


### PR DESCRIPTION
This adds support for case-insensitive tags and validation of invalid types:

https://github.com/alex/django-taggit/commit/0c8013f580cae1b024fefb4439eda61738afdb57
https://github.com/alex/django-taggit/commit/bb3dc0a98d6d2c9efa87ef0a6fd79e172f7ed62e