### PR TITLE
Deprecate the Model._meta.child_relations property

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -59,8 +59,10 @@ For more examples, see the unit tests.
 
 Introspection
 -------------
-If you need to find out which child relations exist on a parent model - to create a deep copy of the model and all its children, say - django-modelcluster defines a ``child_relations`` property on the model's ``_meta`` object. However, this only includes relations that are defined to that specific model class, not any of its superclasses. To retrieve the complete list of relations, accounting for superclasses, use the ``modelcluster.models.get_all_child_relations`` function::
+If you need to find out which child relations exist on a parent model - to create a deep copy of the model and all its children, say - use the ``modelcluster.models.get_all_child_relations`` function::
 
  >>> from modelcluster.models import get_all_child_relations
  >>> get_all_child_relations(Band)
  [<RelatedObject: tests:bandmember related to band>, <RelatedObject: tests:album related to band>]
+
+This includes relations that are defined on any superclasses of the parent model.

--- a/modelcluster/fields.py
+++ b/modelcluster/fields.py
@@ -16,7 +16,6 @@ except ImportError:
 from modelcluster.utils import sort_by_fields
 
 from modelcluster.queryset import FakeQuerySet
-from modelcluster.models import ClusterableModel
 
 
 def create_deferring_foreign_related_manager(related, original_manager_cls):
@@ -228,17 +227,9 @@ class ParentalKey(ForeignKey):
     # This check was moved to the save() method in Django 1.8.4
     allow_unsaved_instance_assignment = True
 
-    def contribute_to_related_class(self, cls, related):
-        super(ParentalKey, self).contribute_to_related_class(cls, related)
-
-        # store this as a child field in meta. NB child_relations only contains relations
-        # defined to this specific model, not its superclasses
-        try:
-            cls._meta.child_relations.append(related)
-        except AttributeError:
-            cls._meta.child_relations = [related]
-
     def check(self, **kwargs):
+        from modelcluster.models import ClusterableModel
+
         errors = super(ParentalKey, self).check(**kwargs)
 
         # Check that the destination model is a subclass of ClusterableModel.

--- a/tests/tests/test_cluster.py
+++ b/tests/tests/test_cluster.py
@@ -3,6 +3,8 @@ from __future__ import unicode_literals
 from django.test import TestCase
 from django.db import IntegrityError
 
+from modelcluster.models import get_all_child_relations
+
 from tests.models import Band, BandMember, Restaurant, Review, Album
 
 
@@ -278,3 +280,11 @@ class ClusterTest(TestCase):
         self.assertEqual(error.id, 'fields.E300')
         self.assertEqual(error.obj, Instrument.banana.field)
         self.assertEqual(error.msg, "Field defines a relation with model 'Banana', which is either not installed, or is abstract.")
+
+
+class GetAllChildRelationsTest(TestCase):
+    def test_get_all_child_relations(self):
+        self.assertEqual(
+            set([rel.name for rel in get_all_child_relations(Restaurant)]),
+            set(['tagged_items', 'reviews', 'menu_items'])
+        )


### PR DESCRIPTION
Adding our own properties to _meta is very hacky, and child_relations is universally less useful than the result of get_all_child_relations (which in turn can be implemented much more simply based on _meta.get_fields(), an official API since Django 1.8).